### PR TITLE
Arreglando error GET /dogs

### DIFF
--- a/src/routes/dogs.js
+++ b/src/routes/dogs.js
@@ -98,7 +98,7 @@ router.get('/', async (req, res) => {
       dogsDB = await Dog.findAll({
         where: {
           name: {
-            [Op.like]: `%${name[0].toUpperCase() + name.slice(1).toLowerCase() || ''}%`
+            [Op.like]: `%${(name && name[0].toUpperCase() + name.slice(1).toLowerCase()) || ''}%`
           }
         },
         attributes: { exclude: ['createdAt', 'updatedAt'] },


### PR DESCRIPTION
se modificó la condición de búsqueda en la base de datos cuando el nombre no era definido en la solicitud