### PR TITLE
Solicitud GET /dogs solo retorna perros con imagen en la DB

### DIFF
--- a/src/routes/dogs.js
+++ b/src/routes/dogs.js
@@ -99,6 +99,9 @@ router.get('/', async (req, res) => {
         where: {
           name: {
             [Op.like]: `%${(name && name[0].toUpperCase() + name.slice(1).toLowerCase()) || ''}%`
+          },
+          image: {
+            [Op.not]: 'true'
           }
         },
         attributes: { exclude: ['createdAt', 'updatedAt'] },


### PR DESCRIPTION
Se añadió una condición de filtrado para la base de datos de tal forma que solo reconozca las razas de perro que contengan una imagen asociada.