### PR TITLE
Error de mostrado de años de vida

### DIFF
--- a/src/routes/dogs.js
+++ b/src/routes/dogs.js
@@ -134,7 +134,7 @@ router.get('/:razaPerro', async (req, res) => {
             name: dog.name,
             height: dog.height.imperial,
             weight: dog.weight.imperial,
-            lifeSpan: dog.lifeSpan,
+            lifeSpan: dog.life_span,
             temperament: dog.temperament,
             image: dog.reference_image_id && `https://cdn2.thedogapi.com/images/${dog.reference_image_id}.jpg`
           }))


### PR DESCRIPTION
Se arregló el error que no permitía mostrar los años de vida de las razas, incluso cuando si estaban declaradas.